### PR TITLE
Run tests for Gazebo PR 2941

### DIFF
--- a/.github/workflows/conda-forge-ci-build-and-tests.yml
+++ b/.github/workflows/conda-forge-ci-build-and-tests.yml
@@ -25,7 +25,8 @@ jobs:
     - name: Clone gazebo repo
       shell: bash -l {0}
       run: |
-        git clone https://github.com/osrf/gazebo
+        git clone https://github.com/traversaro/gazebo
+        git checkout patch-3
 
     - uses: conda-incubator/setup-miniconda@v2
       with:

--- a/.github/workflows/conda-forge-ci-build-and-tests.yml
+++ b/.github/workflows/conda-forge-ci-build-and-tests.yml
@@ -26,6 +26,7 @@ jobs:
       shell: bash -l {0}
       run: |
         git clone https://github.com/traversaro/gazebo
+        cd gazebo
         git checkout patch-3
 
     - uses: conda-incubator/setup-miniconda@v2


### PR DESCRIPTION
Do not merge, this is only useful to check if https://github.com/osrf/gazebo/pull/2941 actually fixes the test failure: 
~~~
2021-03-03T08:54:55.9713520Z 153/402 Test #153: UNIT_OpenAL_TEST ......................................Subprocess aborted***Exception:   0.18 sec
2021-03-03T08:54:55.9714680Z [==========] Running 11 tests from 1 test case.
2021-03-03T08:54:55.9716330Z [----------] Global test environment set-up.
2021-03-03T08:54:55.9717290Z [----------] 11 tests from OpenAL
2021-03-03T08:54:55.9717760Z [ RUN      ] OpenAL.SourceInvalid
2021-03-03T08:54:55.9718670Z [1;31m[Err] [OpenAL.cc:154] [0m[1;31mAudio device not open
2021-03-03T08:54:55.9719570Z [0m[       OK ] OpenAL.SourceInvalid (0 ms)
2021-03-03T08:54:55.9720100Z [ RUN      ] OpenAL.DefaultDevice
2021-03-03T08:54:55.9721140Z [1;33mWarning [parser.cc:636][0m Converting a deprecated SDF source[data-string].
2021-03-03T08:54:55.9721870Z dyld: lazy symbol binding failed: Symbol not found: _alcOpenDevice
2021-03-03T08:54:55.9723300Z   Referenced from: /Users/runner/work/gazebo-conda-force-ci/gazebo-conda-force-ci/gazebo/build/gazebo/util/libgazebo_util.11.dylib
2021-03-03T08:54:55.9724180Z   Expected in: flat namespace
2021-03-03T08:54:55.9724460Z 
2021-03-03T08:54:55.9724840Z dyld: Symbol not found: _alcOpenDevice
2021-03-03T08:54:55.9726190Z   Referenced from: /Users/runner/work/gazebo-conda-force-ci/gazebo-conda-force-ci/gazebo/build/gazebo/util/libgazebo_util.11.dylib
2021-03-03T08:54:55.9727080Z   Expected in: flat namespace
~~~

that it happens with the current gazebo11 branch, see for example: https://github.com/traversaro/gazebo-conda-forge-ci/runs/2020134469 .

Note that in any case OpenAL is deprecated on macOS. 